### PR TITLE
Fix limit of 1024 characters when reading files

### DIFF
--- a/android/src/main/java/com/benwixen/rnfilesystem/RNFileSystem.java
+++ b/android/src/main/java/com/benwixen/rnfilesystem/RNFileSystem.java
@@ -91,7 +91,12 @@ public class RNFileSystem extends ReactContextBaseJavaModule {
       throw new FileNotFoundException();
     }
 
-    return new Scanner(location).useDelimiter("\\Z").next();
+    Scanner scanner = new Scanner(location).useDelimiter("\\Z");
+    String content = "";
+    while (scanner.hasNext()) {
+      content += scanner.next();
+    }
+    return content;
   }
 
   public boolean fileExists(String relativePath, Storage storage) {


### PR DESCRIPTION
I was having trouble reading files containing more than 1024 characters on Android and came up with this solution, I thought it could be useful.