### PR TITLE
Fix compiler error on Android

### DIFF
--- a/android/src/main/java/com/benwixen/rnfilesystem/RNFileSystemPackage.java
+++ b/android/src/main/java/com/benwixen/rnfilesystem/RNFileSystemPackage.java
@@ -15,7 +15,7 @@ public class RNFileSystemPackage implements ReactPackage {
     return Collections.<NativeModule>singletonList(new RNFileSystem(reactContext));
   }
 
-  @Override
+  // deprecated >= RN 0.47.0
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
I am using React Native 0.50.3 and could not compile my Android app after installing this module.

The solution is removing an "@Override" tag, however I am not sure what would happen when trying to compile using React Native < 0.47.0.